### PR TITLE
Track owner change for borrowed accounts 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,8 @@ impl WritableAccount for AccountSharedData {
         match self {
             Self::Borrowed(acc) => unsafe {
                 acc.cow();
-                *acc.owner = owner
+                acc.owner_changed = *acc.owner != owner;
+                *acc.owner = owner;
             },
             Self::Owned(acc) => acc.owner = owner,
         }


### PR DESCRIPTION
feat: track owner field change for borrowed account
this allows to avoid index checks to enforce consistency upon owner
change (which is a relatively rare event)

Depends on: [PR](https://github.com/magicblock-labs/solana-account/pull/2)

[gh-issue](https://github.com/magicblock-labs/magicblock-validator/issues/443)