### PR TITLE
Draft: track delegation status in account

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,8 @@ impl WritableAccount for AccountSharedData {
         match self {
             Self::Borrowed(acc) => unsafe {
                 acc.cow();
-                *acc.owner = owner
+                acc.owner_changed = *acc.owner != owner;
+                *acc.owner = owner;
             },
             Self::Owned(acc) => acc.owner = owner,
         }


### PR DESCRIPTION
Added a boolean bit flag to serialized account format, in order to track the delegation status of the given account. The flag can be set and unset via methods on AccountSharedData. 

Depends on #3 

