### PR TITLE
ci: add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+name: CI
+
+jobs:
+  ci:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+
+      - name: Setup Rust nightly for formatting
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          override: false
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Check formatting
+        run: cargo +nightly fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_serde() {
-        let (_, owned, borrowed) = setup!();
+        let (_buffer, owned, borrowed) = setup!();
         assert!(
             accounts_equal(&borrowed, &owned),
             "deserialization of serialized account should result in the same account"
@@ -619,7 +619,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_to_owned() {
-        let (_, owned, mut borrowed) = setup!();
+        let (_buffer, owned, mut borrowed) = setup!();
         let len = borrowed.data().len();
         let msg = b"hello world?";
         borrowed.extend_from_slice(msg);
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_setting_data_from_slice() {
-        let (_, _, mut borrowed) = setup!();
+        let (_buffer, _, mut borrowed) = setup!();
         let len = borrowed.data().len();
         let msg = b"hello world?";
         borrowed.set_data_from_slice(msg);
@@ -667,7 +667,7 @@ mod tests {
 
     #[test]
     fn test_account_shrinking() {
-        let (_, _, mut borrowed) = setup!();
+        let (_buffer, _, mut borrowed) = setup!();
         borrowed.resize(0, 0);
         assert_eq!(
             borrowed.data(),
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_account_growth() {
-        let (_, _, mut borrowed) = setup!();
+        let (_buffer, _, mut borrowed) = setup!();
         borrowed.resize(SPACE * 2, 0);
         assert_eq!(
             borrowed.data().len(),
@@ -730,7 +730,7 @@ mod tests {
 
     #[test]
     fn test_owner_changed() {
-        let (_, _, mut borrowed) = setup!();
+        let (_buffer, _, mut borrowed) = setup!();
         borrowed.set_owner(Pubkey::default());
         let AccountSharedData::Borrowed(borrowed) = borrowed else {
             panic!("Borrowed account should not have been upgraded to Owned after owner change");
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn test_bitflags() {
-        let (_, _, mut borrowed) = setup!();
+        let (_buffer, _, mut borrowed) = setup!();
         assert!(
             !borrowed.delegated(),
             "account should not be delegated by default"


### PR DESCRIPTION
## Summary

Adding one CI script that runs unit tests, lint and fmt checks, modeled after the
magicblock-validator repo.

Combined all of them into one b/c here it is overkill to install rust toolchain each time.
