### PR TITLE
feat: add remote slot tracking and data cloning support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -698,6 +698,13 @@ impl AccountSharedData {
         }
     }
 
+    pub fn data_clone(&self) -> Arc<Vec<u8>> {
+        // NOTE: original implementation: Arc::clone(&self.data), but we don't have a `data` field.
+        // See: https://github.com/anza-xyz/solana-sdk/blob/master/account/src/lib.rs#L600
+        // This just satisfies the compiler, but due to copying is not performant.
+        Arc::new(self.data().to_vec())
+    }
+
     #[inline]
     fn data_mut(&mut self) -> &mut [u8] {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ impl From<Account> for AccountSharedData {
             owner: other.owner,
             executable: other.executable,
             rent_epoch: other.rent_epoch,
+            remote_slot: u64::default(),
         })
     }
 }
@@ -345,6 +346,7 @@ impl WritableAccount for AccountSharedData {
             owner,
             executable,
             rent_epoch,
+            remote_slot: u64::default(),
             delegated: false,
         })
     }
@@ -447,6 +449,7 @@ impl fmt::Debug for AccountSharedData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("AccountSharedData");
         debug_fmt(self, &mut f);
+        f.field("remote_slot", &self.remote_slot());
         f.field("delegated", &self.delegated());
         f.finish()
     }
@@ -628,6 +631,7 @@ impl AccountSharedData {
                     owner: *acc.owner,
                     executable: acc.flags.is_set(EXECUTABLE_FLAG_INDEX),
                     rent_epoch: Epoch::MAX,
+                    remote_slot: *acc.remote_slot,
                     delegated,
                 })
             }
@@ -648,6 +652,23 @@ impl AccountSharedData {
         match self {
             Self::Borrowed(acc) => acc.flags.is_set(DELEGATED_FLAG_INDEX),
             Self::Owned(acc) => acc.delegated,
+        }
+    }
+
+    pub fn remote_slot(&self) -> u64 {
+        match self {
+            Self::Borrowed(acc) => unsafe { *acc.remote_slot },
+            Self::Owned(acc) => acc.remote_slot,
+        }
+    }
+
+    pub fn set_remote_slot(&mut self, remote_slot: u64) {
+        match self {
+            Self::Owned(acc) => acc.remote_slot = remote_slot,
+            Self::Borrowed(acc) => unsafe {
+                acc.cow();
+                *acc.remote_slot = remote_slot;
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

This PR adds remote slot tracking capabilities and data cloning functionality to the Solana account management system:

- Added `remote_slot` field to track slot numbers for account data
- Implemented `data_clone()` method that returns `Arc<Vec<u8>>` for efficient data sharing
(mainly to stay compatible with upstream Solana crate)

## Details

### Remote Slot Tracking

Added a new `remote_slot` field to both `AccountBorrowed` and `AccountOwned` structures to enable tracking of slot numbers associated with account data. This field is:

- Properly serialized/deserialized in the account data format
- Included in pointer translation for borrowed accounts
- Exposed through public getter and setter methods (`remote_slot()` and `set_remote_slot()`)
- Added to debug output for better observability

### Data Cloning Support

Implemented the `data_clone()` method that returns an `Arc<Vec<u8>>` containing a copy of the
account data. While this implementation copies data rather than sharing the underlying buffer
(due to current architecture constraints), it provides the expected API surface for
compatibility with upstream Solana SDK patterns.
