### PR TITLE
feat: add compressed flag to Account implementation

### DIFF
--- a/src/cow.rs
+++ b/src/cow.rs
@@ -60,7 +60,6 @@ use std::{
     },
 };
 
-use solana_clock::Epoch;
 use solana_pubkey::Pubkey;
 
 use crate::AccountSharedData;
@@ -121,13 +120,26 @@ pub struct AccountBorrowed {
     /// Flags include:
     /// - `0`: `executable`
     /// - `1`: `delegated`
+    /// - `2`: `privileged`
     /// - `3`: `compressed`
     pub(crate) flags: BitFlags,
 }
 
 /// A wrapper for a raw pointer to a `u32` used for bit-packed flags.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BitFlags(*mut u32);
+
+/// A wrapper for a `u8` used for bit-packed flags.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct BitFlagsOwned(u8);
+
+impl From<BitFlags> for BitFlagsOwned {
+    fn from(val: BitFlags) -> Self {
+        // SAFETY:
+        // *mut u32 in BitFlags is alwasy properly initialized
+        Self(unsafe { *val.0 } as u8)
+    }
+}
 
 impl From<AccountBorrowed> for AccountSharedData {
     fn from(value: AccountBorrowed) -> Self {
@@ -263,16 +275,14 @@ pub struct AccountOwned {
     pub(crate) data: Arc<Vec<u8>>,
     /// The program that owns this account.
     pub(crate) owner: Pubkey,
-    /// Whether this account's data contains a loaded program.
-    pub(crate) executable: bool,
-    /// The epoch at which this account will next owe rent.
-    pub(crate) rent_epoch: Epoch,
     /// Remote slot number.
     pub(crate) remote_slot: u64,
-    /// A flag to track if the account has been delegated.
-    pub(crate) delegated: bool,
-    /// A flag to track if the account data is compressed on chain.
-    pub(crate) compressed: bool,
+    /// Various boolean flags (bit packed)
+    /// 0. executable
+    /// 1. delegated
+    /// 2. privileged (inaccessable)
+    /// 3. compressed
+    pub(crate) flags: BitFlagsOwned,
 }
 
 impl Default for AccountSharedData {
@@ -425,9 +435,7 @@ impl AccountSharedData {
         // 5. Remote Slot
         serializer.write(acc.remote_slot);
         // 6. Flags (bit-packed)
-        let flags = (acc.executable as u32) << EXECUTABLE_FLAG_INDEX
-            | (acc.delegated as u32) << DELEGATED_FLAG_INDEX
-            | (acc.compressed as u32) << COMPRESSED_FLAG_INDEX;
+        let flags = acc.flags.0 as u32;
         serializer.write(flags);
         // 7. Data Capacity
         let data_capacity = single_buffer_capacity.saturating_sub(Self::ACCOUNT_STATIC_SIZE);
@@ -534,6 +542,22 @@ impl BitFlags {
         // SAFETY: This is only called during CoW, where `offset` is a valid
         // distance to the corresponding field in the shadow buffer.
         self.0 = unsafe { (self.0 as *mut u8).offset(offset) as *mut u32 };
+    }
+}
+
+impl BitFlagsOwned {
+    /// Checks if the bit at `index` is set.
+    pub(crate) fn is_set(&self, index: u32) -> bool {
+        (self.0 >> index) & 1 == 1
+    }
+
+    /// Sets or clears the bit at `index`.
+    pub(crate) fn set(&mut self, val: bool, index: u32) {
+        if val {
+            self.0 |= 1 << index;
+        } else {
+            self.0 &= !(1 << index);
+        }
     }
 }
 
@@ -659,6 +683,8 @@ unsafe impl Sync for AccountSeqLock {}
 
 #[cfg(test)]
 mod tests {
+    use solana_clock::Epoch;
+
     use super::*;
     use crate::test_utils::create_borrowed_account_shared_data;
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to mark accounts as compressed and query their compression state.

* **Refactor**
  * Optimized internal account property storage mechanism to use a new bit-flag system for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This PR adds support for a compressed flag to the Solana Account implementation, following the same pattern as existing executable and delegated flags. The compressed flag tracks whether account data is compressed on-chain and is persisted across serialization/deserialization cycles.

Agent thread: https://ampcode.com/threads/T-bcf18e4e-f942-4121-8057-b3567c77ca36

## Details

### Account Flag System Enhancement

Extended the existing bit-packed flag system to include a new compressed flag at index 3, maintaining backward compatibility with the current memory layout. The flag is properly integrated into both borrowed and owned account variants.

### API Changes

- Added `set_compressed(bool)` method to modify the compressed state
- Added `compressed() -> bool` method to query the compressed state
- Updated `Debug` implementation to display the compressed flag value
- Enhanced account conversion logic to preserve compressed flag during borrowed-to-owned transitions

### Memory Layout

The compressed flag is stored alongside existing flags in the bit-packed flags field, using efficient memory representation without increasing the account footprint. All serialization and deserialization logic properly handles the new flag.

### Testing

Comprehensive test coverage added including:
- Flag persistence across memory-mapped operations
- Proper isolation from other flags (executable, delegated, privileged)
- Correct behavior in both borrowed and owned account variants
